### PR TITLE
fix: stock movements calls

### DIFF
--- a/src/classes/stock-movements.class.ts
+++ b/src/classes/stock-movements.class.ts
@@ -1,0 +1,163 @@
+import { StockMovement } from '../types/prestashop.type';
+import { Endpoint } from '../enums/endpoint.enum';
+import {
+  DeleteParams,
+  GetParams,
+  ListParams,
+  PostParams,
+  PutParams,
+} from '../types/global.type';
+import {
+  PrestashopAPIResponse,
+  StockMovementsResponse,
+} from '../types/calls.type';
+import { customCall } from '../utils/calls';
+
+export class StockMovements {
+  endpoint = Endpoint.stockMvt;
+
+  /**
+   * List all stock movements from endpoint.
+   *
+   * @param params
+   * @returns
+   */
+  list = async (
+    params: ListParams<StockMovement> | undefined = { display: 'full' }
+  ): Promise<PrestashopAPIResponse<StockMovement[]>> => {
+    const response = await customCall<Partial<StockMovementsResponse>>({
+      method: 'GET',
+      path: '/stock_mvt',
+      params,
+    });
+
+    return {
+      data: response?.stock_movements || [],
+      errors: response?.errors,
+    };
+  };
+
+  /**
+   * Get a single stock movement by id.
+   *
+   * @param id
+   * @param params
+   * @returns
+   */
+  get = async (
+    id: number,
+    params: GetParams | undefined = { display: 'full' }
+  ): Promise<PrestashopAPIResponse<StockMovement>> => {
+    const response = await customCall<StockMovementsResponse>({
+      method: 'GET',
+      path: `/stock_mvt/${id}`,
+      params,
+    });
+
+    if (response?.stock_movements && response?.stock_movements.length > 0) {
+      return {
+        data: response?.stock_movements[0] || [],
+        errors: response?.errors,
+      };
+    }
+
+    return {
+      data: undefined,
+      errors: response?.errors,
+    };
+  };
+
+  /**
+   * Create a stock movement.
+   *
+   * @param body
+   * @param params
+   * @returns
+   */
+  create = async (
+    body: Partial<StockMovement>,
+    params: PostParams | undefined = { display: 'full' }
+  ): Promise<PrestashopAPIResponse<StockMovement>> => {
+    const response = await customCall<StockMovementsResponse>({
+      method: 'POST',
+      path: '/stock_mvt',
+      body: { stock_mvt: body },
+      params,
+    });
+
+    if (response?.stock_movements && response?.stock_movements.length > 0) {
+      return {
+        data: response?.stock_movements[0] || [],
+        errors: response?.errors,
+      };
+    }
+
+    return {
+      data: undefined,
+      errors: response?.errors,
+    };
+  };
+
+  /**
+   * Update a stock movement by id.
+   *
+   * @param id
+   * @param body
+   * @param params
+   * @returns
+   */
+  update = async (
+    id: number,
+    body: Partial<StockMovement>,
+    params: PutParams | undefined = { display: 'full' }
+  ): Promise<PrestashopAPIResponse<StockMovement>> => {
+    const response = await customCall<StockMovementsResponse>({
+      method: 'PUT',
+      path: `/stock_mvt/${id}`,
+      body: { stock_mvt: body },
+      params,
+    });
+
+    if (response?.stock_movements && response?.stock_movements.length > 0) {
+      return {
+        data: response?.stock_movements[0] || [],
+        errors: response?.errors,
+      };
+    }
+
+    return {
+      data: undefined,
+      errors: response?.errors,
+    };
+  };
+
+  /**
+   * Delete a stock movement by id.
+   *
+   * @param id
+   * @param params
+   * @returns
+   */
+  delete = async (
+    id: number,
+    params: DeleteParams | undefined = { display: 'full' }
+  ): Promise<PrestashopAPIResponse<StockMovement>> => {
+    const response = await customCall<StockMovementsResponse>({
+      method: 'DELETE',
+      path: `/stock_mvt/${id}`,
+      params,
+    });
+
+    if (response?.stock_movements && response?.stock_movements.length > 0) {
+      return {
+        data: response?.stock_movements[0] || [],
+        errors: response?.errors,
+      };
+    }
+
+    return {
+      data: undefined,
+      errors: response?.errors,
+    };
+  };
+}

--- a/src/enums/endpoint.enum.ts
+++ b/src/enums/endpoint.enum.ts
@@ -55,6 +55,7 @@ export enum Endpoint {
   stockAvailables = 'stock_availables',
   stockMovementReasons = 'stock_movement_reasons',
   stockMovements = 'stock_movements',
+  stockMvt = 'stock_mvt',
   stocks = 'stocks',
   stores = 'stores',
   suppliers = 'suppliers',

--- a/src/initializers/endpoints.ts
+++ b/src/initializers/endpoints.ts
@@ -47,7 +47,6 @@ import {
   State,
   Stock,
   StockAvailable,
-  StockMovement,
   StockMovementReason,
   Store,
   Supplier,
@@ -68,6 +67,7 @@ import {
 } from '../types/prestashop.type';
 import { Base, Customers, Images } from '../classes';
 import { Custom } from '../classes/custom.class';
+import { StockMovements } from '../classes/stock-movements.class';
 
 /**
  * Initiliaze and export all endpoints.
@@ -148,7 +148,7 @@ export const stockAvailables = new Base<StockAvailable>(
 export const stockMovementReasons = new Base<StockMovementReason>(
   Endpoint.stockMovementReasons
 );
-export const stockMovements = new Base<StockMovement>(Endpoint.stockMovements);
+export const stockMovements = new StockMovements();
 export const stocks = new Base<Stock>(Endpoint.stocks);
 export const stores = new Base<Store>(Endpoint.stores);
 export const suppliers = new Base<Supplier>(Endpoint.suppliers);

--- a/src/types/calls.type.ts
+++ b/src/types/calls.type.ts
@@ -4,7 +4,7 @@ import type {
   RawAxiosRequestHeaders,
   ResponseType,
 } from 'axios';
-import { Customer } from './prestashop.type';
+import { Customer, StockMovement } from './prestashop.type';
 import { Endpoint } from '../enums/endpoint.enum';
 
 export type CallParams = {
@@ -15,11 +15,6 @@ export type CallParams = {
   headers?: Partial<RawAxiosRequestHeaders>;
   paramsSerializer?: ParamsSerializerOptions;
   responseType?: ResponseType;
-};
-
-export type LoginResponse = {
-  success: boolean;
-  customer?: Partial<Customer>;
 };
 
 export type PrestashopAPIResponse<T> = {
@@ -36,4 +31,14 @@ export type PrestashopErrorResponse<T> = {
 export type PrestashopAPIDeleteResponse = {
   success: boolean;
   errors: unknown[] | undefined;
+};
+
+export type LoginResponse = {
+  success: boolean;
+  customer?: Partial<Customer>;
+};
+
+export type StockMovementsResponse = {
+  stock_movements?: StockMovement[];
+  errors?: unknown[];
 };


### PR DESCRIPTION
You can't POST, PUT and DELETE on the stock_movements route so we have call on stock_mvt.

The problem with the stock_mvt route is that the key returned is named "stock_movements" so we can't just rename the endpoint.