### PR TITLE
fix: optional associations orders

### DIFF
--- a/src/types/prestashop.type.ts
+++ b/src/types/prestashop.type.ts
@@ -750,7 +750,7 @@ export type Order = {
   round_type: string;
   conversion_rate: string;
   reference: string;
-  associations: {
+  associations?: {
     order_rows: OrderRow[];
   };
 };


### PR DESCRIPTION
It's possible de delete all the order details of an order. If it's the case, the order will not return any value for associations.

Fix: optional associations in order type